### PR TITLE
Wasteland: Update ChunkDesc height after generating.

### DIFF
--- a/Wasteland/Wasteland.lua
+++ b/Wasteland/Wasteland.lua
@@ -93,6 +93,8 @@ function OnChunkGenerated(World, ChunkX, ChunkZ, ChunkDesc)
 				end
 			end
 		end
+		
+		ChunkDesc:UpdateHeightmap()
 
 		return true
 	--end


### PR DESCRIPTION
This is needed for the server to function correctly.
Debug-mode server failed an assert when this was missing.
